### PR TITLE
Add predelete hook to clear cache when an alert is deleted

### DIFF
--- a/tide_alert.module
+++ b/tide_alert.module
@@ -93,3 +93,13 @@ function tide_alert_node_presave(EntityInterface $entity) {
     Cache::invalidateTags($site->getCacheTagsToInvalidate());
   }
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_predelete().
+ */
+function tide_alert_node_predelete(EntityInterface $entity) {
+    if ($entity->bundle() == 'alert') {
+        $site = $entity->field_node_site->entity;
+        Cache::invalidateTags($site->getCacheTagsToInvalidate());
+    }
+}

--- a/tide_alert.module
+++ b/tide_alert.module
@@ -98,8 +98,8 @@ function tide_alert_node_presave(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_predelete().
  */
 function tide_alert_node_predelete(EntityInterface $entity) {
-    if ($entity->bundle() == 'alert') {
-        $site = $entity->field_node_site->entity;
-        Cache::invalidateTags($site->getCacheTagsToInvalidate());
-    }
+  if ($entity->bundle() == 'alert') {
+    $site = $entity->field_node_site->entity;
+    Cache::invalidateTags($site->getCacheTagsToInvalidate());
+  }
 }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-4372

### Changed

1. Added a predelete hook on alerts to clear cache when an alert is deleted.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
